### PR TITLE
0.2.6

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@
  * ```
  *
  * @param  {Function} `fn` Function that will be called only once.
+ * @param  {Object} `options` Options to determine how modules are cached.
+ * @param  {Boolean} `options.unlazy` When set to `true`, `fn` is called immediately. Defaults to `false`.
  * @return {Function} Function that can be called to get the cached function
  * @api public
  */

--- a/index.js
+++ b/index.js
@@ -16,10 +16,15 @@
  * @api public
  */
 
-function lazyCache(fn) {
+function lazyCache(fn, opts) {
+  opts = opts || {};
   var cache = {};
   var proxy = function (mod, name) {
     name = name || camelcase(mod);
+    if (opts.unlazy === true) {
+      cache[name] = fn(mod);
+    }
+
     Object.defineProperty(proxy, name, {
       enumerable: true,
       configurable: true,
@@ -30,11 +35,7 @@ function lazyCache(fn) {
       if (cache.hasOwnProperty(name)) {
         return cache[name];
       }
-      try {
-        return (cache[name] = fn(mod));
-      } catch (err) {
-        throw err;
-      }
+      return (cache[name] = fn(mod));
     }
     return getter;
   };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lazy-cache",
   "description": "Cache requires to be lazy-loaded when needed.",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "homepage": "https://github.com/jonschlinkert/lazy-cache",
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",
   "repository": "jonschlinkert/lazy-cache",

--- a/test.js
+++ b/test.js
@@ -39,6 +39,27 @@ describe('lazy-cache', function () {
     assert.deepEqual(calls, {'ansi-yellow': 1});
   });
 
+  it('should allow loading a dependency immediately with `unlazy` option', function() {
+    var calls = {};
+    var lazy = lazyCache(function(mod) {
+      calls[mod] = (calls[mod] || 0) + 1;
+      return require(mod);
+    }, {unlazy: true});
+
+    assert.deepEqual(calls, {});
+    lazy('ansi-yellow');
+    assert.deepEqual(calls, {'ansi-yellow': 1});
+
+    lazy.ansiYellow('one');
+    assert.deepEqual(calls, {'ansi-yellow': 1});
+    lazy.ansiYellow('two');
+    assert.deepEqual(calls, {'ansi-yellow': 1});
+    lazy.ansiYellow('three');
+    assert.deepEqual(calls, {'ansi-yellow': 1});
+    lazy.ansiYellow('four');
+    assert.deepEqual(calls, {'ansi-yellow': 1});
+  });
+
   it('should support passing an alias as the second argument:', function () {
     var calls = {};
     var lazy = lazyCache(function (mod) {


### PR DESCRIPTION
Adding `options` to method with an `unlazy` flag that will allow loading modules immediately. This is useful in modules that may need to ensure all dependencies are loaded before adding require hooks.
