### PR TITLE
Add Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,16 @@ os:
 language: node_js
 node_js:
   - node
+  - '14'
+  - '12'
+  - '10'
   - '6'
-  - '4'
-  - '0.12'
-  - '0.10'
+
+arch:
+  - amd64
+  - ppc64le
+
+jobs:
+  exclude:
+   - arch: ppc64le
+     os: osx


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.