### PR TITLE
create cache from an object without prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var set = require('set-getter');
  */
 
 function lazyCache(requireFn) {
-  var cache = {};
+  var cache = Object.create(null);
 
   return function proxy(name, alias) {
     var key = alias;


### PR DESCRIPTION
it will prevent to mess with object prototype methods